### PR TITLE
VG-519 Make the worker CLI-like

### DIFF
--- a/coins/bitcoin/common/src/main/scala/co/ledger/lama/bitcoin/common/clients/grpc/mocks/KeychainClientMock.scala
+++ b/coins/bitcoin/common/src/main/scala/co/ledger/lama/bitcoin/common/clients/grpc/mocks/KeychainClientMock.scala
@@ -10,7 +10,7 @@ import co.ledger.lama.bitcoin.common.clients.grpc.KeychainClient
 
 import scala.collection.mutable
 
-class KeychainClientMock extends KeychainClient {
+class KeychainClientMock(createdKeychainId: Option[UUID] = None) extends KeychainClient {
 
   var usedAddresses: mutable.Seq[String] = mutable.Seq.empty
 
@@ -69,7 +69,7 @@ class KeychainClientMock extends KeychainClient {
   ): IO[KeychainInfo] =
     IO.delay(
       KeychainInfo(
-        UUID.randomUUID(),
+        createdKeychainId.getOrElse(UUID.randomUUID()),
         "",
         "",
         "",

--- a/coins/bitcoin/worker/src/it/scala/co/ledger/lama/bitcoin/worker/WorkerIT.scala
+++ b/coins/bitcoin/worker/src/it/scala/co/ledger/lama/bitcoin/worker/WorkerIT.scala
@@ -52,7 +52,6 @@ class WorkerIT extends AnyFlatSpecLike with Matchers {
           )
 
         val worker = new Worker(
-          args,
           keychainClient,
           explorerClient,
           interpreterClient,
@@ -65,7 +64,8 @@ class WorkerIT extends AnyFlatSpecLike with Matchers {
           Coin.Btc
         )
 
-        worker.run
+        worker
+          .run(args)
           .map { result =>
             it should "have 35 used addresses for the account" in {
               keychainClient.usedAddresses.size shouldBe 19 + 35

--- a/coins/bitcoin/worker/src/it/scala/co/ledger/lama/bitcoin/worker/WorkerIT.scala
+++ b/coins/bitcoin/worker/src/it/scala/co/ledger/lama/bitcoin/worker/WorkerIT.scala
@@ -1,18 +1,16 @@
 package co.ledger.lama.bitcoin.worker
 
-import cats.effect.{ContextShift, IO, Resource, Timer}
+import cats.effect.{ContextShift, IO, Timer}
 import co.ledger.lama.bitcoin.common.clients.grpc.mocks.{InterpreterClientMock, KeychainClientMock}
 import co.ledger.lama.bitcoin.common.clients.http.ExplorerHttpClient
-import co.ledger.lama.bitcoin.common.models.explorer.Block
+import co.ledger.lama.bitcoin.common.models.Scheme
+import co.ledger.lama.bitcoin.common.models.keychain.AccountKey.Xpub
+import co.ledger.lama.bitcoin.worker.SynchronizationResult.{SynchronizationSuccess}
 import co.ledger.lama.bitcoin.worker.config.Config
-import co.ledger.lama.bitcoin.worker.services.{CursorStateService, RabbitSyncEventService}
+import co.ledger.lama.bitcoin.worker.services.{CursorStateService}
 import co.ledger.lama.common.models._
 import co.ledger.lama.common.services.Clients
 import co.ledger.lama.common.utils.IOAssertion
-import co.ledger.lama.common.utils.rabbitmq.RabbitUtils
-import dev.profunktor.fs2rabbit.interpreter.RabbitClient
-import dev.profunktor.fs2rabbit.model.{ExchangeName, ExchangeType, QueueName, RoutingKey}
-import fs2.Stream
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import pureconfig.ConfigSource
@@ -28,156 +26,67 @@ class WorkerIT extends AnyFlatSpecLike with Matchers {
 
   val conf: Config = ConfigSource.default.loadOrThrow[Config]
 
-  val rabbit: Resource[IO, RabbitClient[IO]] = Clients.rabbit(conf.rabbit)
-
-  val resources = for {
-    rabbitClient <- rabbit
-    httpClient   <- Clients.htt4s
-  } yield (rabbitClient, httpClient)
-
   IOAssertion {
-    setupRabbit() *>
-      resources
-        .use { case (rabbitClient, httpClient) =>
-          val syncEventService = new RabbitSyncEventService(
-            rabbitClient,
-            conf.queueName(conf.workerEventsExchangeName),
-            conf.lamaEventsExchangeName,
-            conf.routingKey
-          )
+    Clients.htt4s
+      .use { httpClient =>
+        val keychainId = UUID.randomUUID()
 
-          val keychainClient = new KeychainClientMock
+        val keychainClient = new KeychainClientMock(Some(keychainId))
 
-          val explorerClient = new ExplorerHttpClient(httpClient, conf.explorer, _)
+        val explorerClient = new ExplorerHttpClient(httpClient, conf.explorer, _)
 
-          val interpreterClient = new InterpreterClientMock
+        val interpreterClient = new InterpreterClientMock
 
-          val cursorStateService: Coin => CursorStateService[IO] =
-            c => CursorStateService(explorerClient(c), interpreterClient).getLastValidState(_, _, _)
+        val cursorStateService: Coin => CursorStateService[IO] =
+          c => CursorStateService(explorerClient(c), interpreterClient).getLastValidState(_, _, _)
 
-          val worker = new Worker(
-            syncEventService,
-            keychainClient,
-            explorerClient,
-            interpreterClient,
-            cursorStateService
-          )
-
-          val accountManager = new SimpleAccountManager(
-            rabbitClient,
-            conf.queueName(conf.lamaEventsExchangeName),
-            conf.workerEventsExchangeName,
-            conf.routingKey
-          )
-
-          val keychainId = UUID.randomUUID()
-
-          val account = Account(
-            keychainId.toString,
-            CoinFamily.Bitcoin,
-            Coin.Btc
-          )
-
-          val syncId = UUID.randomUUID()
-
-          val registeredMessage = WorkableEvent[Block](
-            account,
-            syncId,
-            Status.Registered,
+        val args: SynchronizationParameters =
+          SynchronizationParameters(
+            Xpub("xpubtoto"),
+            Scheme.Bip44,
+            Coin.Btc,
+            UUID.randomUUID(),
             None,
-            None,
-            Instant.now()
+            UUID.randomUUID(),
+            20
           )
 
-          Stream
-            .eval {
-              accountManager.publishWorkerEvent(registeredMessage) *>
-                accountManager.consumeReportEvent
+        val worker = new Worker(
+          args,
+          keychainClient,
+          explorerClient,
+          interpreterClient,
+          cursorStateService
+        )
+
+        val account = Account(
+          keychainId.toString,
+          CoinFamily.Bitcoin,
+          Coin.Btc
+        )
+
+        worker.run
+          .map { result =>
+            it should "have 35 used addresses for the account" in {
+              keychainClient.usedAddresses.size shouldBe 19 + 35
             }
-            .concurrently(worker.run)
-            .take(1)
-            .compile
-            .last
-            .map { reportEvent =>
-              it should "have 35 used addresses for the account" in {
-                keychainClient.usedAddresses.size shouldBe 19 + 35
-              }
 
-              val expectedTxsSize         = 73
-              val expectedLastBlockHeight = 644553L
+            val expectedTxsSize         = 73
+            val expectedLastBlockHeight = 644553L
 
-              it should s"have synchronized $expectedTxsSize txs with last blockHeight > $expectedLastBlockHeight" in {
-                interpreterClient.getSavedTransaction(account.id) should have size expectedTxsSize
+            it should s"have synchronized $expectedTxsSize txs with last blockHeight > $expectedLastBlockHeight" in {
+              interpreterClient.getSavedTransaction(account.id) should have size expectedTxsSize
 
-                reportEvent should not be empty
-                reportEvent.get.account shouldBe account
-
-                val event = reportEvent.get
-                event.cursor.get.height should be > expectedLastBlockHeight
-                event.cursor.get.time should be > Instant.parse("2020-08-20T13:01:16Z")
+              result match {
+                case SynchronizationSuccess(_, newCursor) =>
+                  newCursor.height should be > expectedLastBlockHeight
+                  newCursor.time should be > Instant.parse("2020-08-20T13:01:16Z")
+                case _ =>
+                  fail("synchronization should succeed")
               }
             }
-        }
+          }
+      }
   }
-
-  def setupRabbit(): IO[Unit] =
-    rabbit.use { client =>
-      for {
-        _ <- RabbitUtils.deleteBindings(
-          client,
-          List(
-            conf.queueName(conf.workerEventsExchangeName),
-            conf.queueName(conf.lamaEventsExchangeName)
-          )
-        )
-        _ <- RabbitUtils.deleteExchanges(
-          client,
-          List(conf.workerEventsExchangeName, conf.lamaEventsExchangeName)
-        )
-        _ <- RabbitUtils.declareExchanges(
-          client,
-          List(
-            (conf.workerEventsExchangeName, ExchangeType.Topic),
-            (conf.lamaEventsExchangeName, ExchangeType.Topic)
-          )
-        )
-        res <- RabbitUtils.declareBindings(
-          client,
-          List(
-            (
-              conf.workerEventsExchangeName,
-              conf.routingKey,
-              conf.queueName(conf.workerEventsExchangeName)
-            ),
-            (
-              conf.lamaEventsExchangeName,
-              conf.routingKey,
-              conf.queueName(conf.lamaEventsExchangeName)
-            )
-          )
-        )
-      } yield res
-    }
-
-}
-
-class SimpleAccountManager(
-    rabbit: RabbitClient[IO],
-    lamaEventsQueueName: QueueName,
-    workerEventsExchangeName: ExchangeName,
-    routingKey: RoutingKey
-) {
-
-  private lazy val consumer: Stream[IO, ReportableEvent[Block]] =
-    RabbitUtils.createAutoAckConsumer[ReportableEvent[Block]](rabbit, lamaEventsQueueName)
-
-  private lazy val publisher: Stream[IO, WorkableEvent[Block] => IO[Unit]] =
-    RabbitUtils.createPublisher[WorkableEvent[Block]](rabbit, workerEventsExchangeName, routingKey)
-
-  def consumeReportEvent: IO[ReportableEvent[Block]] =
-    consumer.take(1).compile.last.map(_.get)
-
-  def publishWorkerEvent(message: WorkableEvent[Block]): IO[Unit] =
-    publisher.evalMap(p => p(message)).compile.drain
 
 }

--- a/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/App.scala
+++ b/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/App.scala
@@ -58,18 +58,17 @@ object App extends IOApp with DefaultContextLogging {
 
       val cliOptions = res.args
 
-      val args = SynchronizationParameters(
+      val syncParams = SynchronizationParameters(
         cliOptions.xpub,
         cliOptions.scheme,
         cliOptions.coin,
         cliOptions.syncId,
-        cliOptions.cursor,
-        cliOptions.walletId,
+        cliOptions.blockHash,
+        cliOptions.walletUid,
         cliOptions.lookahead
       )
 
       val worker = new Worker(
-        args,
         keychainClient,
         explorerClient,
         interpreterClient,
@@ -78,7 +77,7 @@ object App extends IOApp with DefaultContextLogging {
       for {
         _ <- IO(res.server.start()) *> log.info("Worker started")
 
-        res <- worker.run.as(ExitCode.Success)
+        res <- worker.run(syncParams).as(ExitCode.Success)
       } yield res
     }
   }

--- a/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/SynchronizationParameters.scala
+++ b/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/SynchronizationParameters.scala
@@ -11,7 +11,7 @@ case class SynchronizationParameters(
     scheme: Scheme,
     coin: Coin,
     syncId: UUID,
-    cursor: Option[String],
-    walletId: UUID,
+    blockHash: Option[String],
+    walletUid: UUID,
     lookahead: Int
 )

--- a/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/SynchronizationParameters.scala
+++ b/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/SynchronizationParameters.scala
@@ -1,0 +1,17 @@
+package co.ledger.lama.bitcoin.worker
+
+import co.ledger.lama.bitcoin.common.models.Scheme
+import co.ledger.lama.bitcoin.common.models.keychain.AccountKey.Xpub
+import co.ledger.lama.common.models.Coin
+
+import java.util.UUID
+
+case class SynchronizationParameters(
+    xpub: Xpub,
+    scheme: Scheme,
+    coin: Coin,
+    syncId: UUID,
+    cursor: Option[String],
+    walletId: UUID,
+    lookahead: Int
+)

--- a/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/SynchronizationResult.scala
+++ b/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/SynchronizationResult.scala
@@ -1,0 +1,12 @@
+package co.ledger.lama.bitcoin.worker
+
+import co.ledger.lama.bitcoin.common.models.explorer.Block
+
+sealed abstract class SynchronizationResult {
+  def parameters: SynchronizationParameters
+}
+object SynchronizationResult {
+  final case class SynchronizationSuccess(parameters: SynchronizationParameters, newCursor: Block) extends SynchronizationResult
+
+  final case class SynchronizationFailure(parameters: SynchronizationParameters, throwable: Throwable) extends SynchronizationResult
+}

--- a/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/cli/CommandLineOptions.scala
+++ b/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/cli/CommandLineOptions.scala
@@ -1,0 +1,48 @@
+package co.ledger.lama.bitcoin.worker.cli
+
+import cats.data.{NonEmptyList, Validated}
+import com.monovore.decline._
+import cats.implicits._
+import co.ledger.lama.bitcoin.common.models.Scheme
+import co.ledger.lama.bitcoin.common.models.keychain.AccountKey.Xpub
+import co.ledger.lama.common.models.Coin
+
+import java.util.UUID
+
+case class CommandLineOptions(
+    xpub: Xpub,
+    scheme: Scheme,
+    coin: Coin,
+    syncId: UUID,
+    cursor: Option[String],
+    walletId: UUID,
+    lookahead: Int
+)
+
+object CommandLineOptions {
+  val opts: Opts[CommandLineOptions] = {
+    val xpub = Opts.option[String]("xpub", "The extended public key").map(Xpub(_))
+    val scheme = Opts
+      .option[String]("scheme", "The xpub scheme")
+      .mapValidated(s =>
+        Validated.fromOption(Scheme.fromKey(s), NonEmptyList.one(s"$s is not a valid scheme"))
+      )
+    val syncId   = Opts.option[UUID]("syncId", "The synchronization id")
+    val cursor   = Opts.option[String]("cursor", "The current hash of the blockchain").orNone
+    val walletId = Opts.option[UUID]("walletId", "The id of the wallet the xpub belongs to")
+    val coin = Opts
+      .option[String]("coin", "The coin to synchronize")
+      .mapValidated(c =>
+        Validated.fromOption(Coin.fromKey(c), NonEmptyList.one(s"$c is not a valid coin"))
+      )
+    val lookahead =
+      Opts.option[Int]("lookahead", "The HD wallet (BIP-32) lookahead").withDefault(20)
+
+    (xpub, scheme, coin, syncId, cursor, walletId, lookahead).mapN(
+      CommandLineOptions(_, _, _, _, _, _, _)
+    )
+  }
+
+  val command: Command[CommandLineOptions] =
+    Command("cria-worker-bitcoin", "The cria synchronization worker for BTC-like coins")(opts)
+}

--- a/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/cli/CommandLineOptions.scala
+++ b/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/cli/CommandLineOptions.scala
@@ -14,8 +14,8 @@ case class CommandLineOptions(
     scheme: Scheme,
     coin: Coin,
     syncId: UUID,
-    cursor: Option[String],
-    walletId: UUID,
+    blockHash: Option[String],
+    walletUid: UUID,
     lookahead: Int
 )
 
@@ -27,9 +27,9 @@ object CommandLineOptions {
       .mapValidated(s =>
         Validated.fromOption(Scheme.fromKey(s), NonEmptyList.one(s"$s is not a valid scheme"))
       )
-    val syncId   = Opts.option[UUID]("syncId", "The synchronization id")
-    val cursor   = Opts.option[String]("cursor", "The current hash of the blockchain").orNone
-    val walletId = Opts.option[UUID]("walletId", "The id of the wallet the xpub belongs to")
+    val syncId    = Opts.option[UUID]("syncId", "The synchronization id")
+    val blockHash = Opts.option[String]("blockHash", "The current hash of the blockchain").orNone
+    val walletUid = Opts.option[UUID]("walletUid", "The id of the wallet the xpub belongs to")
     val coin = Opts
       .option[String]("coin", "The coin to synchronize")
       .mapValidated(c =>
@@ -38,7 +38,7 @@ object CommandLineOptions {
     val lookahead =
       Opts.option[Int]("lookahead", "The HD wallet (BIP-32) lookahead").withDefault(20)
 
-    (xpub, scheme, coin, syncId, cursor, walletId, lookahead).mapN(
+    (xpub, scheme, coin, syncId, blockHash, walletUid, lookahead).mapN(
       CommandLineOptions(_, _, _, _, _, _, _)
     )
   }

--- a/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/config.scala
+++ b/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/config.scala
@@ -14,7 +14,6 @@ object config {
   case class Config(
       workerEventsExchangeName: ExchangeName,
       lamaEventsExchangeName: ExchangeName,
-      rabbit: Fs2RabbitConfig,
       explorer: ExplorerConfig,
       keychain: GrpcClientConfig,
       interpreter: GrpcClientConfig,

--- a/coins/bitcoin/worker/src/test/scala/co/ledger/lama/bitcoin/worker/KeychainFixture.scala
+++ b/coins/bitcoin/worker/src/test/scala/co/ledger/lama/bitcoin/worker/KeychainFixture.scala
@@ -19,7 +19,8 @@ object KeychainFixture {
 
   def keychainClient(
       addresses: LazyList[Address],
-      lookaheadSize: Int = 20
+      lookaheadSize: Int = 20,
+      keyChainId: Option[UUID] = None
   ): KeychainClient with UsedAddressesTracker =
     new KeychainClient with UsedAddressesTracker {
 
@@ -28,7 +29,19 @@ object KeychainFixture {
           scheme: Scheme,
           lookaheadSize: Int,
           network: BitcoinLikeNetwork
-      ): IO[KeychainInfo] = ???
+      ): IO[KeychainInfo] =
+        IO.delay(
+          KeychainInfo(
+            keyChainId.getOrElse(UUID.randomUUID()),
+            "",
+            "",
+            "",
+            "",
+            lookaheadSize,
+            scheme,
+            network
+          )
+        )
 
       override def getKeychainInfo(keychainId: UUID): IO[KeychainInfo] =
         IO.delay(

--- a/coins/bitcoin/worker/src/test/scala/co/ledger/lama/bitcoin/worker/WorkerSpec.scala
+++ b/coins/bitcoin/worker/src/test/scala/co/ledger/lama/bitcoin/worker/WorkerSpec.scala
@@ -5,22 +5,18 @@ import co.ledger.lama.bitcoin.common.clients.grpc.InterpreterClient
 import co.ledger.lama.bitcoin.common.clients.grpc.mocks.InterpreterClientMock
 import co.ledger.lama.bitcoin.common.clients.http.ExplorerClient
 import co.ledger.lama.bitcoin.common.clients.http.mocks.ExplorerClientMock
+import co.ledger.lama.bitcoin.common.models.Scheme.Bip44
 import co.ledger.lama.bitcoin.common.models.explorer.Block
-import co.ledger.lama.bitcoin.worker.SyncEventServiceFixture.{End, QueueInputOps, registered}
-import co.ledger.lama.bitcoin.worker.services.{CursorStateService, SyncEventService}
-import co.ledger.lama.common.models.Status.Registered
-import co.ledger.lama.common.models.{Account, Coin, CoinFamily, ReportableEvent, WorkableEvent}
+import co.ledger.lama.bitcoin.common.models.interpreter.TransactionView
+import co.ledger.lama.bitcoin.common.models.keychain.AccountKey.Xpub
+import co.ledger.lama.bitcoin.worker.services.CursorStateService
+import co.ledger.lama.common.models.{Account, Coin, CoinFamily}
 import co.ledger.lama.common.utils.IOAssertion
-import fs2.concurrent.Queue
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
 import java.time.Instant
 import java.util.UUID
-
-import co.ledger.lama.bitcoin.common.models.interpreter.TransactionView
-import co.ledger.lama.common.utils.rabbitmq.AutoAckMessage
-import dev.profunktor.fs2rabbit.model.DeliveryTag
-
 import scala.concurrent.ExecutionContext
 
 class WorkerSpec extends AnyFlatSpec with Matchers {
@@ -28,9 +24,11 @@ class WorkerSpec extends AnyFlatSpec with Matchers {
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit val t: Timer[IO]         = IO.timer(ExecutionContext.global)
 
+  val keychainId = UUID.randomUUID()
+
   val accountIdentifier =
     Account(
-      UUID.randomUUID().toString,
+      keychainId.toString,
       CoinFamily.Bitcoin,
       Coin.Btc
     )
@@ -60,52 +58,28 @@ class WorkerSpec extends AnyFlatSpec with Matchers {
   val alreadyValidBlockCursorService: CursorStateService[IO] = (_, b, _) => IO.pure(b)
 
   def worker(
-      messages: Queue[IO, Option[WorkableEvent[Block]]],
+      args: SynchronizationParameters,
       interpreter: InterpreterClient = new InterpreterClientMock,
       explorer: ExplorerClient = defaultExplorer
   ) = new Worker(
-    SyncEventServiceFixture.syncEventService(receiving = messages),
-    KeychainFixture.keychainClient(accountAddresses),
+    args,
+    KeychainFixture.keychainClient(accountAddresses, keyChainId = Some(keychainId)),
     _ => explorer,
     interpreter,
     _ => alreadyValidBlockCursorService
   )
 
-  "Worker" should "run on each Registered event received" in IOAssertion {
-
-    for {
-      events <- SyncEventServiceFixture.workableEvents
-
-      runs = worker(events).run
-
-      _ <- registered(accountIdentifier, cursor = None) >> events
-      _ <- registered(accountIdentifier, cursor = None) >> events
-      _ <- End >> events
-
-      nbRuns <- runs.compile.toList.map(_.size)
-
-    } yield {
-      nbRuns shouldBe 2
-    }
-  }
-
-  it should "synchronize on registered event" in IOAssertion {
+  it should "synchronize on given parameters" in IOAssertion {
 
     val interpreter = new InterpreterClientMock
 
     assert(interpreter.getSavedTransaction(accountIdentifier.id).isEmpty)
 
+    val args = mkArgs(None)
+
     for {
-      events <- SyncEventServiceFixture.workableEvents
-      runs = worker(events, interpreter).run
-
-      _ <- registered(accountIdentifier, cursor = None) >> events
-      _ <- End >> events
-
-      _ <- runs.compile.drain
-
+      _ <- worker(args, interpreter).run
     } yield {
-
       val txs: List[TransactionView] = interpreter.getSavedTransaction(accountIdentifier.id)
       txs should have size 4
     }
@@ -120,15 +94,10 @@ class WorkerSpec extends AnyFlatSpec with Matchers {
 
     assert(interpreter.getSavedTransaction(accountIdentifier.id).isEmpty)
 
+    val args = mkArgs(Some(lastMinedBlock))
+
     for {
-      events <- SyncEventServiceFixture.workableEvents
-      runs = worker(events, interpreter, explorer).run
-
-      _ <- registered(accountIdentifier, cursor = Some(lastMinedBlock)) >> events
-      _ <- End >> events
-
-      _ <- runs.compile.drain
-
+      _ <- worker(args, interpreter, explorer).run
     } yield {
 
       interpreter.getSavedTransaction(accountIdentifier.id) shouldBe empty
@@ -142,63 +111,26 @@ class WorkerSpec extends AnyFlatSpec with Matchers {
     val explorer =
       new ExplorerClientMock(blockchain.flatMap(_._2).toMap, mempool.toMap)
 
+    val args = mkArgs(Some(lastMinedBlock))
+    val w    = worker(args, explorer = explorer)
     for {
-      events <- SyncEventServiceFixture.workableEvents
-      runs = worker(messages = events, explorer = explorer).run
-
-      _ <- registered(accountIdentifier, cursor = Some(lastMinedBlock)) >> events
-      _ <- registered(accountIdentifier, cursor = Some(lastMinedBlock)) >> events
-      _ <- End >> events
-
-      _ <- runs.compile.drain
-
+      _ <- w.run
+      _ <- w.run
     } yield {
       explorer.getUnConfirmedTransactionsCount = 2
     }
-
   }
-}
 
-object SyncEventServiceFixture {
-
-  def workableEvents(implicit
-      cs: ContextShift[IO]
-  ): IO[Queue[IO, Option[WorkableEvent[Block]]]] =
-    Queue.bounded[IO, Option[WorkableEvent[Block]]](5)
-
-  def registered(
-      accountId: Account,
+  def mkArgs(
       cursor: Option[Block]
-  ): WorkableEvent[Block] =
-    WorkableEvent(
-      accountId,
+  ): SynchronizationParameters =
+    SynchronizationParameters(
+      Xpub("xpubtoto"),
       syncId = UUID.randomUUID(),
-      status = Registered,
-      cursor,
-      error = None,
-      Instant.now()
+      scheme = Bip44,
+      coin = Coin.Btc,
+      cursor = cursor.map(_.hash),
+      walletId = UUID.randomUUID(),
+      lookahead = 20
     )
-
-  def syncEventService(
-      receiving: Queue[IO, Option[WorkableEvent[Block]]]
-  ): SyncEventService = {
-    new SyncEventService {
-      override def consumeWorkerEvents: fs2.Stream[IO, AutoAckMessage[WorkableEvent[Block]]] = {
-        receiving.dequeue.unNoneTerminate
-          .evalMap { event =>
-            AutoAckMessage.wrap(event, DeliveryTag(0L))(_ => IO.unit)
-          }
-      }
-
-      override def reportEvent(message: ReportableEvent[Block]): IO[Unit] = IO.unit
-    }
-  }
-
-  object End {
-    def >>[T](queue: Queue[IO, Option[T]]): IO[Unit] = queue.enqueue1(None)
-  }
-  implicit class QueueInputOps[M](e: M) {
-    def >>(queue: Queue[IO, Option[M]]): IO[Unit] = queue.enqueue1(Some(e))
-  }
-
 }

--- a/coins/bitcoin/worker/src/test/scala/co/ledger/lama/bitcoin/worker/cli/CommandLineOptionsTest.scala
+++ b/coins/bitcoin/worker/src/test/scala/co/ledger/lama/bitcoin/worker/cli/CommandLineOptionsTest.scala
@@ -1,0 +1,40 @@
+package co.ledger.lama.bitcoin.worker.cli
+
+import co.ledger.lama.bitcoin.common.models.Scheme
+import co.ledger.lama.bitcoin.common.models.keychain.AccountKey.Xpub
+import co.ledger.lama.common.models.Coin
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.util.UUID
+
+class CommandLineOptionsTest extends AnyFlatSpec {
+  it should "parse successfully" in {
+    val xpub = Xpub(
+      "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz"
+    )
+    val scheme   = Scheme.Bip44
+    val coin     = Coin.Btc
+    val syncId   = UUID.randomUUID()
+    val hash     = "00000000000000000004bd803d1489f7df4d139987ed2ee761d0eb0726d2c088"
+    val walletId = UUID.randomUUID()
+    val rawArgs: List[String] = List(
+      "--xpub",
+      xpub.extendedPublicKey,
+      "--scheme",
+      scheme.name,
+      "--coin",
+      coin.toString,
+      "--syncId",
+      syncId.toString,
+      "--cursor",
+      hash,
+      "--walletId",
+      walletId.toString
+    )
+    val expected = Right(CommandLineOptions(xpub, scheme, coin, syncId, Some(hash), walletId, 20))
+
+    val actual = CommandLineOptions.command.parse(rawArgs)
+
+    assert(actual == expected)
+  }
+}

--- a/coins/bitcoin/worker/src/test/scala/co/ledger/lama/bitcoin/worker/cli/CommandLineOptionsTest.scala
+++ b/coins/bitcoin/worker/src/test/scala/co/ledger/lama/bitcoin/worker/cli/CommandLineOptionsTest.scala
@@ -12,11 +12,11 @@ class CommandLineOptionsTest extends AnyFlatSpec {
     val xpub = Xpub(
       "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz"
     )
-    val scheme   = Scheme.Bip44
-    val coin     = Coin.Btc
-    val syncId   = UUID.randomUUID()
-    val hash     = "00000000000000000004bd803d1489f7df4d139987ed2ee761d0eb0726d2c088"
-    val walletId = UUID.randomUUID()
+    val scheme    = Scheme.Bip44
+    val coin      = Coin.Btc
+    val syncId    = UUID.randomUUID()
+    val hash      = "00000000000000000004bd803d1489f7df4d139987ed2ee761d0eb0726d2c088"
+    val walletUid = UUID.randomUUID()
     val rawArgs: List[String] = List(
       "--xpub",
       xpub.extendedPublicKey,
@@ -26,12 +26,12 @@ class CommandLineOptionsTest extends AnyFlatSpec {
       coin.toString,
       "--syncId",
       syncId.toString,
-      "--cursor",
+      "--blockHash",
       hash,
-      "--walletId",
-      walletId.toString
+      "--walletUid",
+      walletUid.toString
     )
-    val expected = Right(CommandLineOptions(xpub, scheme, coin, syncId, Some(hash), walletId, 20))
+    val expected = Right(CommandLineOptions(xpub, scheme, coin, syncId, Some(hash), walletUid, 20))
 
     val actual = CommandLineOptions.command.parse(rawArgs)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,6 +49,12 @@ object Dependencies extends DependencyBuilders with LibraryManagementSyntax {
     "com.github.pureconfig"      %% "pureconfig-cats"          % pureconfigVersion
   )
 
+  val declineVersion      = "2.0.0"
+
+  val cli: Seq[ModuleID] = Seq(
+    "com.monovore" %% "decline" % declineVersion
+  )
+
   val fs2RabbitVersion = "3.0.1"
   val rabbit: Seq[ModuleID] = Seq(
     "dev.profunktor" %% "fs2-rabbit" % fs2RabbitVersion
@@ -88,7 +94,7 @@ object Dependencies extends DependencyBuilders with LibraryManagementSyntax {
   val criaCommon: Seq[ModuleID] = circe ++ rabbit ++ utilities ++ postgres ++ http4s
 
   val btcCommon: Seq[ModuleID]      = criaCommon
-  val btcWorker: Seq[ModuleID]      = btcCommon
+  val btcWorker: Seq[ModuleID]      = btcCommon ++ cli
   val btcInterpreter: Seq[ModuleID] = btcCommon ++ crypto
   val btcApi: Seq[ModuleID]         = btcCommon
   val btcTransactor: Seq[ModuleID]  = btcCommon


### PR DESCRIPTION
This commit makes the cria worker CLI-like in order to launch it once
per synchronization in a kubernetes pod.

Before this commit, the worker would get its work from RMQ (1 message =
1 sync). Now it gets its work from the command line (1 run = 1 sync).

These are the defined CLI options on the cria worker (from the help):
```
--xpub <string>
    The extended public key
--scheme <string>
    The xpub scheme
--coin <string>
    The coin to synchronize
--syncId <uuid>
    The synchronization id
--cursor <string>
    The current hash of the blockchain
--walletId <uuid>
    The id of the wallet the xpub belongs to
--lookahead <integer>
    The HD wallet (BIP-32) lookahead
```

![lama](https://i.chzbgr.com/full/5933863936/hC07E1650/thats-a-happy-llama)
