### PR TITLE
Refactorings before using sqlite

### DIFF
--- a/src/it/scala/co/ledger/cria/domain/services/interpreter/InterpreterIT.scala
+++ b/src/it/scala/co/ledger/cria/domain/services/interpreter/InterpreterIT.scala
@@ -3,8 +3,6 @@ package co.ledger.cria.domain.services.interpreter
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-
-import cats.data.NonEmptyList
 import cats.effect.IO
 import co.ledger.cria.domain.mocks.ExplorerClientMock
 import co.ledger.cria.itutils.ContainerSpec
@@ -17,6 +15,7 @@ import co.ledger.cria.domain.models.interpreter.{
   BlockHash,
   BlockView,
   Coin,
+  Derivation,
   InputView,
   OutputView,
   TransactionView
@@ -43,18 +42,18 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
   override implicit val lc: CriaLogContext = CriaLogContext().withAccountId(accountUid)
 
   private val outputAddress1 =
-    AccountAddress("1DtwACvd338XtHBFYJRVKRLxviD7YtYADa", ChangeType.External, NonEmptyList.of(1, 0))
+    AccountAddress("1DtwACvd338XtHBFYJRVKRLxviD7YtYADa", ChangeType.External, Derivation(1, 0))
   private val outputAddress2 =
     AccountAddress(
       "1LK8UbiRwUzC8KFEbMKvgbvriM9zLMce3C",
       ChangeType.Internal,
-      NonEmptyList.of(0, 0)
+      Derivation(0, 0)
     )
   private val inputAddress =
     keychain.AccountAddress(
       "1LD1pARePgXXyZA1J3EyvRtB82vxENs5wQ",
       ChangeType.External,
-      NonEmptyList.of(1, 1)
+      Derivation(1, 1)
     )
 
   private val time: Instant = Instant.parse("2019-04-04T10:03:22Z")

--- a/src/it/scala/co/ledger/cria/domain/services/interpreter/OperationComputationServiceIT.scala
+++ b/src/it/scala/co/ledger/cria/domain/services/interpreter/OperationComputationServiceIT.scala
@@ -2,13 +2,13 @@ package co.ledger.cria.domain.services.interpreter
 
 import java.time.Instant
 import fs2.Stream
-import cats.data.NonEmptyList
 import co.ledger.cria.domain.models.account.{AccountUid, WalletUid}
 import co.ledger.cria.domain.models.interpreter.{
   AccountTxView,
   BlockHash,
   BlockView,
   Coin,
+  Derivation,
   InputView,
   Operation,
   OperationType,
@@ -36,19 +36,19 @@ class OperationComputationServiceIT
     AccountAddress(
       "1DtwACvd338XtHBFYJRVKRLxviD7YtYADa",
       ChangeType.External,
-      NonEmptyList.of(1, 0)
+      Derivation(1, 0)
     )
   private val outputAddress2 =
     AccountAddress(
       "1LK8UbiRwUzC8KFEbMKvgbvriM9zLMce3C",
       ChangeType.Internal,
-      NonEmptyList.of(0, 0)
+      Derivation(0, 0)
     )
   private val inputAddress =
     keychain.AccountAddress(
       "1LD1pARePgXXyZA1J3EyvRtB82vxENs5wQ",
       ChangeType.External,
-      NonEmptyList.of(1, 1)
+      Derivation(1, 1)
     )
 
   private val time: Instant = Instant.parse("2019-04-04T10:03:22Z")

--- a/src/it/scala/co/ledger/cria/itutils/queries/LamaOperationTestQueries.scala
+++ b/src/it/scala/co/ledger/cria/itutils/queries/LamaOperationTestQueries.scala
@@ -17,6 +17,7 @@ import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import fs2.{Chunk, Pipe, Stream}
+import co.ledger.cria.domain.adapters.persistence.lama.queries.LamaQueryImplicits._
 
 object LamaOperationTestQueries extends DoobieLogHandler {
 

--- a/src/main/scala/co/ledger/cria/domain/adapters/keychain/KeychainClientMock.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/keychain/KeychainClientMock.scala
@@ -1,7 +1,7 @@
 package co.ledger.cria.domain.adapters.keychain
 
-import cats.data.NonEmptyList
 import cats.effect.IO
+import co.ledger.cria.domain.models.interpreter.Derivation
 import co.ledger.cria.domain.models.keychain
 import co.ledger.cria.domain.models.keychain.ChangeType.External
 import co.ledger.cria.domain.models.keychain.{AccountAddress, ChangeType, KeychainId}
@@ -13,7 +13,7 @@ class KeychainClientMock extends KeychainClient {
 
   var usedAddresses: mutable.Seq[String] = mutable.Seq.empty
 
-  private val derivations: NonEmptyList[Int] = NonEmptyList(1, List(0))
+  private val derivations: Derivation = Derivation(1, 0)
   private val change: External.type          = ChangeType.External
 
   val derivedAddresses: List[AccountAddress] = List(
@@ -54,7 +54,7 @@ class KeychainClientMock extends KeychainClient {
     keychain.AccountAddress("1Aj3Gi1j5UsvZh4ccjaqdnogPMWy54Z5ii", change, derivations)
   ) ++ (1 to 20).map(i => keychain.AccountAddress(s"unused$i", change, derivations))
 
-  private val derivationsInternal: NonEmptyList[Int] = NonEmptyList(1, List(1))
+  private val derivationsInternal: Derivation = Derivation(1, 1)
   val derivedAddressesInternal: List[AccountAddress] =
     (1 to 20)
       .map(i => keychain.AccountAddress(s"changeAddr$i", ChangeType.Internal, derivationsInternal))

--- a/src/main/scala/co/ledger/cria/domain/adapters/keychain/PBHelper.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/keychain/PBHelper.scala
@@ -1,6 +1,6 @@
 package co.ledger.cria.domain.adapters.keychain
 
-import cats.data.NonEmptyList
+import co.ledger.cria.domain.models.interpreter.Derivation
 import co.ledger.cria.domain.models.keychain.{AccountAddress, ChangeType}
 import co.ledger.cria.domain.models.keychain.ChangeType.{External, Internal}
 import co.ledger.protobuf.bitcoin.keychain
@@ -8,12 +8,14 @@ import co.ledger.protobuf.bitcoin.keychain
 object PBHelper {
   object accountAddress {
 
-    def fromKeychainProto(proto: keychain.AddressInfo): AccountAddress =
+    def fromKeychainProto(proto: keychain.AddressInfo): AccountAddress = {
+      val derivationList = proto.derivation.toList
       AccountAddress(
         proto.address,
         changeType.fromKeychainProto(proto.change),
-        NonEmptyList.fromListUnsafe(proto.derivation.toList)
+        Derivation(derivationList(0), derivationList(1))
       )
+    }
   }
 
   object changeType {

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/lama/queries/LamaOperationQueries.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/lama/queries/LamaOperationQueries.scala
@@ -14,6 +14,7 @@ import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import fs2.Stream
+import LamaQueryImplicits._
 
 object LamaOperationQueries extends DoobieLogHandler {
 
@@ -93,7 +94,7 @@ object LamaOperationQueries extends DoobieLogHandler {
   ): ConnectionIO[Int] = {
     val queries = addresses.map { addr =>
       sql"""UPDATE input
-            SET derivation = ${addr.derivation.toList}
+            SET derivation = ${addr.derivation}
             WHERE account_id = $accountId
             AND address = ${addr.accountAddress}
          """
@@ -110,7 +111,7 @@ object LamaOperationQueries extends DoobieLogHandler {
     val queries = addresses.map { addr =>
       sql"""UPDATE output
             SET change_type = $changeType,
-                derivation = ${addr.derivation.toList}
+                derivation = ${addr.derivation}
             WHERE account_id = $accountId
             AND address = ${addr.accountAddress}
          """

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/lama/queries/LamaQueryImplicits.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/lama/queries/LamaQueryImplicits.scala
@@ -1,0 +1,17 @@
+package co.ledger.cria.domain.adapters.persistence.lama.queries
+
+import co.ledger.cria.domain.models.interpreter.Derivation
+import doobie.postgres.implicits._
+import doobie.{Meta, _}
+
+object LamaQueryImplicits {
+
+  implicit val metaDerivation: Meta[Derivation] = {
+    val put = Put[List[Int]].contramap[Derivation](d => List(d.chain, d.addressNumber))
+    val get = Get[List[Int]].temap {
+      case chain :: addressNumber :: Nil => Right(Derivation(chain, addressNumber))
+      case l                             => Left(s"$l is not a derivation")
+    }
+    new Meta(get, put)
+  }
+}

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/lama/queries/LamaTransactionQueries.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/lama/queries/LamaTransactionQueries.scala
@@ -15,6 +15,7 @@ import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import co.ledger.cria.domain.models.implicits._
+import LamaQueryImplicits._
 import fs2._
 
 import java.time.Instant

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/queries/WDOperationQueries.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/queries/WDOperationQueries.scala
@@ -13,6 +13,7 @@ import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import fs2.Stream
+import WDQueryImplicits._
 
 import java.time.Instant
 
@@ -108,7 +109,7 @@ object WDOperationQueries extends DoobieLogHandler {
   ): ConnectionIO[Int] = {
     val queries = addresses.map { addr =>
       sql"""UPDATE input
-            SET derivation = ${addr.derivation.toList}
+            SET derivation = ${addr.derivation}
             WHERE account_uid = $accountId
             AND address = ${addr.accountAddress}
          """
@@ -125,7 +126,7 @@ object WDOperationQueries extends DoobieLogHandler {
     val queries = addresses.map { addr =>
       sql"""UPDATE output
             SET change_type = $changeType,
-                derivation = ${addr.derivation.toList}
+                derivation = ${addr.derivation}
             WHERE account_uid = $accountId
             AND address = ${addr.accountAddress}
          """

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/queries/WDQueryImplicits.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/queries/WDQueryImplicits.scala
@@ -1,0 +1,16 @@
+package co.ledger.cria.domain.adapters.persistence.wd.queries
+
+import co.ledger.cria.domain.models.interpreter.Derivation
+import doobie._
+import doobie.postgres.implicits._
+
+object WDQueryImplicits {
+  implicit val metaDerivation: Meta[Derivation] = {
+    val put = Put[List[Int]].contramap[Derivation](d => List(d.chain, d.addressNumber))
+    val get = Get[List[Int]].temap {
+      case chain :: addressNumber :: Nil => Right(Derivation(chain, addressNumber))
+      case l                             => Left(s"$l is not a derivation")
+    }
+    new Meta(get, put)
+  }
+}

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/queries/WDTransactionQueries.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/queries/WDTransactionQueries.scala
@@ -10,6 +10,7 @@ import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import fs2._
+import WDQueryImplicits._
 
 object WDTransactionQueries extends DoobieLogHandler {
 

--- a/src/main/scala/co/ledger/cria/domain/models/interpreter/Derivation.scala
+++ b/src/main/scala/co/ledger/cria/domain/models/interpreter/Derivation.scala
@@ -1,0 +1,3 @@
+package co.ledger.cria.domain.models.interpreter
+
+case class Derivation(chain: Int, addressNumber: Int)

--- a/src/main/scala/co/ledger/cria/domain/models/interpreter/InputView.scala
+++ b/src/main/scala/co/ledger/cria/domain/models/interpreter/InputView.scala
@@ -1,7 +1,5 @@
 package co.ledger.cria.domain.models.interpreter
 
-import cats.data.NonEmptyList
-
 case class InputView(
     outputHash: String,
     outputIndex: Int,
@@ -11,7 +9,7 @@ case class InputView(
     scriptSignature: String,
     txinwitness: List[String],
     sequence: Long,
-    derivation: Option[NonEmptyList[Int]]
+    derivation: Option[Derivation]
 ) {
   val belongs: Boolean = derivation.isDefined
 }

--- a/src/main/scala/co/ledger/cria/domain/models/interpreter/OutputView.scala
+++ b/src/main/scala/co/ledger/cria/domain/models/interpreter/OutputView.scala
@@ -1,6 +1,5 @@
 package co.ledger.cria.domain.models.interpreter
 
-import cats.data.NonEmptyList
 import co.ledger.cria.domain.models.keychain.ChangeType
 
 case class OutputView(
@@ -9,7 +8,7 @@ case class OutputView(
     address: String,
     scriptHex: String,
     changeType: Option[ChangeType],
-    derivation: Option[NonEmptyList[Int]]
+    derivation: Option[Derivation]
 ) {
   val belongs: Boolean = derivation.isDefined
 }

--- a/src/main/scala/co/ledger/cria/domain/models/keychain/AccountAddress.scala
+++ b/src/main/scala/co/ledger/cria/domain/models/keychain/AccountAddress.scala
@@ -1,9 +1,9 @@
 package co.ledger.cria.domain.models.keychain
 
-import cats.data.NonEmptyList
+import co.ledger.cria.domain.models.interpreter.Derivation
 
 case class AccountAddress(
     accountAddress: String,
     changeType: ChangeType,
-    derivation: NonEmptyList[Int]
+    derivation: Derivation
 )

--- a/src/test/scala/co/ledger/cria/KeychainFixture.scala
+++ b/src/test/scala/co/ledger/cria/KeychainFixture.scala
@@ -1,8 +1,8 @@
 package co.ledger.cria
 
-import cats.data.NonEmptyList
 import cats.effect.IO
 import co.ledger.cria.clients.explorer.ExplorerClient.Address
+import co.ledger.cria.domain.models.interpreter.Derivation
 import co.ledger.cria.domain.models.keychain
 import co.ledger.cria.domain.models.keychain.{AccountAddress, ChangeType, KeychainId}
 import co.ledger.cria.domain.services.KeychainClient
@@ -32,7 +32,7 @@ object KeychainFixture {
         IO.delay(
           addresses
             .slice(fromIndex, toIndex)
-            .map(AccountAddress(_, ChangeType.External, derivation = NonEmptyList.one(1)))
+            .map(AccountAddress(_, ChangeType.External, derivation = Derivation(1, 0)))
             .toList
         )
 
@@ -51,7 +51,7 @@ object KeychainFixture {
         for {
           knownAddresses <- IO(
             newlyMarkedAddresses.keys.toList.map(
-              keychain.AccountAddress(_, ChangeType.External, derivation = NonEmptyList.one(1))
+              keychain.AccountAddress(_, ChangeType.External, derivation = Derivation(1, 0))
             )
           )
 

--- a/src/test/scala/co/ledger/cria/domain/adapters/persistence/wd/models/WDSpec.scala
+++ b/src/test/scala/co/ledger/cria/domain/adapters/persistence/wd/models/WDSpec.scala
@@ -1,9 +1,8 @@
 package co.ledger.cria.domain.adapters.persistence.wd.models
 
-import cats.data.NonEmptyList
 import co.ledger.cria.domain.models.TxHash
 import co.ledger.cria.domain.models.account.AccountUid
-import co.ledger.cria.domain.models.interpreter.{BlockHash, Coin, OperationType, OutputView}
+import co.ledger.cria.domain.models.interpreter.{BlockHash, Coin, Derivation, OperationType, OutputView}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -48,7 +47,7 @@ class WDSpec extends AnyFlatSpec with Matchers {
   "an operations recipients" should "depend on the operationType" in {
     val belongAddess     = "address1"
     val notBelongAddress = "address2"
-    val belongOutput     = OutputView(0, 0, belongAddess, "", None, Some(NonEmptyList(1, List(0))))
+    val belongOutput     = OutputView(0, 0, belongAddess, "", None, Some(Derivation(1, 0)))
     val notBelongOutput  = OutputView(0, 0, notBelongAddress, "", None, None)
     WDOperation.getRecipients(
       OperationType.Receive,


### PR DESCRIPTION
This commit includes several small refactorings which are used in the
move to sqlite for temporary tables:
- Make derivation a case class instead of a non-empty list
- Remove two unused columns in input

![lama](https://i.pinimg.com/736x/6a/cc/f3/6accf32dcdd7b074d490feb8d8a86c36.jpg)
