### PR TITLE
Fix WD balance queries

### DIFF
--- a/src/it/scala/co/ledger/cria/domain/services/interpreter/InterpreterIT.scala
+++ b/src/it/scala/co/ledger/cria/domain/services/interpreter/InterpreterIT.scala
@@ -70,7 +70,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
   )
   val inputs = List(
     InputView(
-      "0f38e5f1b12078495a9e80c6e0d77af3d674cfe6096bb6e7909993a53b6e8386",
+      TxHash.fromStringUnsafe("0f38e5f1b12078495a9e80c6e0d77af3d674cfe6096bb6e7909993a53b6e8386"),
       0,
       0,
       80000,
@@ -309,6 +309,8 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
 
         val utils = tr.testUtils
 
+        val txHash0 = TxHash.fromStringUnsafe("d0a75f8295419c72782aadb8de23b4d8ed095c9ec3c26a144b8e8f9ab0c11730")
+
         val uTx1 = TransactionView(
           "tx1",
           TxHash.fromStringUnsafe(
@@ -318,7 +320,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
           0,
           1000,
           List(
-            InputView(".", 0, 0, 101000, inputAddress.accountAddress, "script", List(), 0L, None)
+            InputView(txHash0, 0, 0, 101000, inputAddress.accountAddress, "script", List(), 0L, None)
           ),
           List(
             OutputView(0, 100000, outputAddress1.accountAddress, "script", None, None)
@@ -346,7 +348,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
           ),
           inputs = List(
             InputView(
-              "tx1",
+              uTx1.hash,
               0,
               0,
               100000,
@@ -413,7 +415,6 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
           )
           lastBalance        <- utils.getBalance(accountUid)
           lastOperationCount <- utils.getOperationCount(accountUid)
-
         } yield {
 
           firstOperationCount shouldBe 1
@@ -438,6 +439,8 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
 
         val utils = tr.testUtils
 
+        val txHash0 = TxHash.fromStringUnsafe("6a7a2a7365343ac22a30e4971ec9699af7d01d61e33f6b4381b745d556ddc92c")
+
         val uTx1 = AccountTxView(
           accountUid,
           TransactionView(
@@ -449,7 +452,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
             0,
             1000,
             List(
-              InputView(".", 0, 0, 101000, inputAddress.accountAddress, "script", List(), 0L, None)
+              InputView(txHash0, 0, 0, 101000, inputAddress.accountAddress, "script", List(), 0L, None)
             ),
             List(
               OutputView(0, 100000, outputAddress1.accountAddress, "script", None, None)

--- a/src/it/scala/co/ledger/cria/domain/services/interpreter/OperationComputationServiceIT.scala
+++ b/src/it/scala/co/ledger/cria/domain/services/interpreter/OperationComputationServiceIT.scala
@@ -65,7 +65,7 @@ class OperationComputationServiceIT
   )
   val inputs = List(
     InputView(
-      "0f38e5f1b12078495a9e80c6e0d77af3d674cfe6096bb6e7909993a53b6e8386",
+      TxHash.fromStringUnsafe("0f38e5f1b12078495a9e80c6e0d77af3d674cfe6096bb6e7909993a53b6e8386"),
       0,
       0,
       80000,

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/lama/queries/LamaTransactionQueries.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/lama/queries/LamaTransactionQueries.scala
@@ -181,6 +181,7 @@ object LamaTransactionQueries extends DoobieLogHandler {
 
     val inputs  = fetchInputs(accountId, sort, txHashes).stream.through(groupByTxHash)
     val outputs = fetchOutputs(accountId, sort, txHashes).stream.through(groupByTxHash)
+    implicit val txHashOrdering: Ordering[TxHash] = TxHash.orderTxHash.toOrdering
 
     inputs
       .zip(outputs)

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/WDPostSyncCheckService.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/WDPostSyncCheckService.scala
@@ -29,7 +29,7 @@ class WDPostSyncCheckService(db: Transactor[IO]) extends ContextLogging with Pos
       balance = blockchainBalance.balance,
       utxos = blockchainBalance.utxos,
       received = blockchainBalance.received,
-      sent = blockchainBalance.netSent,
+      sent = blockchainBalance.netSent + blockchainBalance.fees,
       unconfirmedBalance = unconfirmedBalance
     )
 

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/models/WDInput.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/models/WDInput.scala
@@ -27,12 +27,12 @@ object WDInput {
       uid = createUid(
         accountUid = accountId,
         outputIndex = input.outputIndex,
-        previousTxHash = input.outputHash,
+        previousTxHash = input.outputHash.asString,
         coinbase = None
       ),
       previousOutputIdx = input.outputIndex,
-      previousTxHash = input.outputHash,
-      previousTxUid = WDTransaction.createUid(accountId, input.outputHash),
+      previousTxHash = input.outputHash.asString,
+      previousTxUid = WDTransaction.createUid(accountId, input.outputHash.asString),
       amount = input.value,
       inputIndex = input.inputIndex,
       address = input.address,

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/queries/WDTransactionQueries.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/queries/WDTransactionQueries.scala
@@ -169,6 +169,7 @@ object WDTransactionQueries extends DoobieLogHandler {
 
     val inputs  = fetchInputs(accountId, sort, txHashes).stream.through(groupByTxHash)
     val outputs = fetchOutputs(accountId, sort, txHashes).stream.through(groupByTxHash)
+    implicit val txHashOrdering: Ordering[TxHash] = TxHash.orderTxHash.toOrdering
 
     inputs
       .zip(outputs)

--- a/src/main/scala/co/ledger/cria/domain/models/TxHash.scala
+++ b/src/main/scala/co/ledger/cria/domain/models/TxHash.scala
@@ -9,7 +9,7 @@ case class TxHash(private val hash: SHA256) extends AnyVal {
 }
 
 object TxHash {
-  implicit val ordering: Order[TxHash] = Order.by(_.hash)
+  implicit val orderTxHash: Order[TxHash] = Order.by(_.hash)
 
   // TODO Move to adaptation layer when dependency split for persistence is done
   implicit val metaHash: Meta[TxHash] = Meta[SHA256].timap(TxHash(_))(_.hash)

--- a/src/main/scala/co/ledger/cria/domain/models/interpreter/InputView.scala
+++ b/src/main/scala/co/ledger/cria/domain/models/interpreter/InputView.scala
@@ -1,7 +1,9 @@
 package co.ledger.cria.domain.models.interpreter
 
+import co.ledger.cria.domain.models.TxHash
+
 case class InputView(
-    outputHash: String,
+    outputHash: TxHash,
     outputIndex: Int,
     inputIndex: Int,
     value: BigInt,

--- a/src/main/scala/co/ledger/cria/domain/services/interpreter/Interpreter.scala
+++ b/src/main/scala/co/ledger/cria/domain/services/interpreter/Interpreter.scala
@@ -43,6 +43,7 @@ class InterpreterImpl(explorer: Coin => ExplorerClient, persistenceFacade: Persi
   private val transactionRecordRepository = persistenceFacade.transactionRecordRepository
   private val operationComputationService = persistenceFacade.operationComputationService
   private val operationRepository         = persistenceFacade.operationRepository
+  private val postSyncCheckService        = persistenceFacade.postSyncCheckService
 
   private val UTXO_LOCKING_TIME = Duration("12 hours")
 
@@ -92,7 +93,7 @@ class InterpreterImpl(explorer: Coin => ExplorerClient, persistenceFacade: Persi
 
       _ <- log.info(s"$nbSavedOps operations saved")
 
-//      _ <- postSyncCheckService.check(account.accountUid)
+      _ <- postSyncCheckService.check(account.accountUid)
     } yield nbSavedOps
   }
 

--- a/src/test/scala/co/ledger/cria/TransactionFixture.scala
+++ b/src/test/scala/co/ledger/cria/TransactionFixture.scala
@@ -29,7 +29,7 @@ object TransactionFixture {
   )
 
   def input(address: Address): InputView = InputView(
-    outputHash = "",
+    outputHash = TxHash.fromStringUnsafe("0eb14f1817ad99446764f190479b8e7f987127113ab3af1504dc4603655f987a"),
     outputIndex = 0,
     inputIndex = 0,
     value = 1L,


### PR DESCRIPTION
This commit fixes the wallet daemon balance queries to use the wallet
daemon tables instead of the temporary tables.
It also reenables the post sync check which checks the balance
invariant (sum of utxos = in - out).

![lama](https://pbs.twimg.com/media/EFzZOeiWoAEFQky.jpg:large)
