### PR TITLE
Improve checks on transaction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,11 @@ scalacOptions ++= CompilerFlags.all
 resolvers += Resolver.sonatypeRepo("releases")
 addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
 
+// it tests
+lazy val ITest = config("it") extend Test
+scalaSource in ITest := baseDirectory.value / "src/it/scala"
+unmanagedResourceDirectories in ITest += baseDirectory.value / "src" / "it" / "resources"
+
 // e2e tests
 lazy val End2EndTest = config("e2e") extend Test
 scalaSource in End2EndTest := baseDirectory.value / "src/it/scala"
@@ -35,7 +40,7 @@ parallelExecution in End2EndTest := false
 // Assign the proper tests to each test conf
 def e2eFilter(name: String): Boolean = name endsWith "E2ETest"
 def itFilter(name: String): Boolean  = (name endsWith "IT") && !e2eFilter(name)
-testOptions in IntegrationTest := Seq(Tests.Filter(itFilter))
+testOptions in ITest := Seq(Tests.Filter(itFilter))
 testOptions in End2EndTest := Seq(Tests.Filter(e2eFilter))
 
 lazy val buildInfoSettings = Seq(
@@ -73,7 +78,8 @@ lazy val bitcoinProtobuf = (project in file("protobuf"))
 
 lazy val cria = (project in file("."))
   .enablePlugins(JavaAgent, JavaServerAppPackaging, DockerPlugin)
-  .configs(IntegrationTest)
+  .configs(ITest)
+  .settings(inConfig(ITest)(Defaults.testSettings))
   .configs(End2EndTest)
   .settings(inConfig(End2EndTest)(Defaults.testSettings))
   .settings(buildInfoSettings)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies extends DependencyBuilders with LibraryManagementSyntax {
     "org.tpolecat"            %% "doobie-scalatest"               % doobieVersion              % "it, test, e2e",
     "com.opentable.components" % "otj-pg-embedded"                % otjPgEmbeddedVersion       % Test,
     "it.ozimov"                % "embedded-redis"                 % embeddedRedisVersion       % Test,
-    "com.dimafeng"            %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % "it, e2e"
+    "com.dimafeng"            %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % "test, it, e2e"
   )
 
   // https://scalapb.github.io/docs/faq/#i-am-getting-import-was-not-found-or-had-errors

--- a/src/it/e2e-resources/test-accounts-btc_testnet.json
+++ b/src/it/e2e-resources/test-accounts-btc_testnet.json
@@ -6,7 +6,7 @@
       },
       "scheme": "BIP44",
       "lookahead_size": 20,
-      "coin": "btc_testnet",
+      "coin": "bitcoin_testnet",
       "sync_id": "f124f9df-507a-450e-a74c-7ff78c583ed7",
       "account_uid": "a59deed9-a6c8-4a57-9dbd-e3b1cf7a9428",
       "wallet_uid": "a7f01c2b-fd4b-45a8-b836-b8106448b189",
@@ -14,12 +14,9 @@
       "metadata": "nolibcore:testworkspace"
     },
     "expected": {
-      "extended_public_key": "tpubDCrucad5KpPS3AD91ZXsSrTbiCCkXJPPo6qHsSuJCbnhSn9MCNaqsY6mvHPaMoCNSS2RHmT36qXhUqTJxqfidfLpM3oRdJJAgveXAfMXUGW",
       "ops_size": 4,
       "utxos_size": 2,
-      "last_tx_hash": "f01ca5b85b3c754ca6f685342b2f17c2ca0d00c562e0864c3bf489738f30e49c",
       "balance": 35480,
-      "balance_history_size": 2,
       "amount_received": 110000,
       "amount_sent": 74520
     }

--- a/src/it/scala/co/ledger/cria/domain/services/CursorStateServiceIT.scala
+++ b/src/it/scala/co/ledger/cria/domain/services/CursorStateServiceIT.scala
@@ -97,12 +97,12 @@ class CursorStateServiceIT extends AnyFlatSpecLike with Matchers with DefaultCon
   }
 
   private def createTx(blockHash: String, height: Long) =
-    TransactionView(
+    TransactionView.unsafe(
       "id",
       TxHash.fromStringUnsafe("b55ba601af2e705c11f8a62dc72c34b052b4f0be0eaf6ba2025e513d86194de9"),
       Instant.now(),
       0L,
-      1,
+      0,
       Nil,
       Nil,
       Some(

--- a/src/it/scala/co/ledger/cria/domain/services/CursorStateServiceIT.scala
+++ b/src/it/scala/co/ledger/cria/domain/services/CursorStateServiceIT.scala
@@ -16,7 +16,7 @@ import co.ledger.cria.domain.models.interpreter.{
   BlockView,
   Coin,
   SyncId,
-  TransactionView
+  TransactionViewTestHelper
 }
 import co.ledger.cria.domain.models.keychain.KeychainId
 import co.ledger.cria.utils.IOAssertion
@@ -97,7 +97,7 @@ class CursorStateServiceIT extends AnyFlatSpecLike with Matchers with DefaultCon
   }
 
   private def createTx(blockHash: String, height: Long) =
-    TransactionView.unsafe(
+    TransactionViewTestHelper.unsafe(
       "id",
       TxHash.fromStringUnsafe("b55ba601af2e705c11f8a62dc72c34b052b4f0be0eaf6ba2025e513d86194de9"),
       Instant.now(),

--- a/src/it/scala/co/ledger/cria/domain/services/interpreter/InterpreterIT.scala
+++ b/src/it/scala/co/ledger/cria/domain/services/interpreter/InterpreterIT.scala
@@ -84,21 +84,24 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
     )
   )
 
+  val someTxHash =
+    TxHash.fromStringUnsafe("cafee5f1b12078495a9e80c6e0d77af3d674cfe6096bb6e7909993a53b6e1664")
+
   val coinbaseTx: TransactionView =
-    TransactionView(
+    TransactionView.unsafe(
       "txId",
       TxHash.fromStringUnsafe("0f38e5f1b12078495a9e80c6e0d77af3d674cfe6096bb6e7909993a53b6e8386"),
       time,
       0,
       0,
-      Nil,
+      List(InputView(someTxHash, 0, 0, 80000, "toto", "sig", Nil, 0, None)),
       List(OutputView(0, 80000, inputAddress.accountAddress, "script", None, None)),
       Some(block),
       1
     )
 
   val insertTx: TransactionView =
-    TransactionView(
+    TransactionView.unsafe(
       "txId",
       TxHash.fromStringUnsafe("a8a935c6bc2bd8b3a7c20f107a9eb5f10a315ce27de9d72f3f4e27ac9ec1eb1f"),
       time,
@@ -207,7 +210,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
 
         val utils = tr.testUtils
 
-        val uTx = TransactionView(
+        val uTx = TransactionView.unsafe(
           "txId",
           TxHash.fromStringUnsafe(
             "a8a935c6bc2bd8b3a7c20f107a9eb5f10a315ce27de9d72f3f4e27ac9ec1eb1f"
@@ -259,7 +262,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
 
         val utils = tr.testUtils
 
-        val uTx = TransactionView(
+        val uTx = TransactionView.unsafe(
           "txId",
           TxHash.fromStringUnsafe(
             "a8a935c6bc2bd8b3a7c20f107a9eb5f10a315ce27de9d72f3f4e27ac9ec1eb1f"
@@ -274,7 +277,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
         )
         explorer.addToBC(uTx)
 
-        val tx = TransactionView(
+        val tx = TransactionView.unsafe(
           "txId",
           TxHash.fromStringUnsafe(
             "a8a935c6bc2bd8b3a7c20f107a9eb5f10a315ce27de9d72f3f4e27ac9ec1eb1f"
@@ -315,7 +318,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
           "d0a75f8295419c72782aadb8de23b4d8ed095c9ec3c26a144b8e8f9ab0c11730"
         )
 
-        val uTx1 = TransactionView(
+        val uTx1 = TransactionView.unsafe(
           "tx1",
           TxHash.fromStringUnsafe(
             "b23ed6a7362a45ed880d29aa601baed2ee718b440a562daf31473a65fc99d0c7"
@@ -351,7 +354,8 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
           ),
           outputs = List(
             OutputView(0, 5000, outputAddress2.accountAddress, "script", None, None)
-          ) // receive
+          ), // receive
+          fees = 96000
         )
         explorer.addToBC(uTx2)
 
@@ -459,7 +463,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
 
         val uTx1 = AccountTxView(
           accountUid,
-          TransactionView(
+          TransactionView.unsafe(
             "utx1",
             TxHash.fromStringUnsafe(
               "a99c7e333b287e7ecb017b33b7faf028a7eba69ae716114401e398f568f6ad9b"

--- a/src/it/scala/co/ledger/cria/domain/services/interpreter/InterpreterIT.scala
+++ b/src/it/scala/co/ledger/cria/domain/services/interpreter/InterpreterIT.scala
@@ -1,6 +1,17 @@
 package co.ledger.cria.domain.services.interpreter
 
-import co.ledger.cria.domain.models.interpreter.BlockHeight
+import co.ledger.cria.domain.models.interpreter.{
+  AccountTxView,
+  BlockHash,
+  BlockHeight,
+  BlockView,
+  Coin,
+  Derivation,
+  InputView,
+  OutputView,
+  TransactionView,
+  TransactionViewTestHelper
+}
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -12,16 +23,6 @@ import co.ledger.cria.utils.IOAssertion
 import co.ledger.cria.logging.CriaLogContext
 import co.ledger.cria.domain.models.{Sort, TxHash, keychain}
 import co.ledger.cria.domain.models.account.{Account, AccountUid, WalletUid}
-import co.ledger.cria.domain.models.interpreter.{
-  AccountTxView,
-  BlockHash,
-  BlockView,
-  Coin,
-  Derivation,
-  InputView,
-  OutputView,
-  TransactionView
-}
 import co.ledger.cria.domain.models.keychain.{AccountAddress, ChangeType, KeychainId}
 import co.ledger.cria.itutils.models.GetUtxosResult
 import org.scalatest.matchers.should.Matchers
@@ -88,7 +89,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
     TxHash.fromStringUnsafe("cafee5f1b12078495a9e80c6e0d77af3d674cfe6096bb6e7909993a53b6e1664")
 
   val coinbaseTx: TransactionView =
-    TransactionView.unsafe(
+    TransactionViewTestHelper.unsafe(
       "txId",
       TxHash.fromStringUnsafe("0f38e5f1b12078495a9e80c6e0d77af3d674cfe6096bb6e7909993a53b6e8386"),
       time,
@@ -101,7 +102,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
     )
 
   val insertTx: TransactionView =
-    TransactionView.unsafe(
+    TransactionViewTestHelper.unsafe(
       "txId",
       TxHash.fromStringUnsafe("a8a935c6bc2bd8b3a7c20f107a9eb5f10a315ce27de9d72f3f4e27ac9ec1eb1f"),
       time,
@@ -210,7 +211,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
 
         val utils = tr.testUtils
 
-        val uTx = TransactionView.unsafe(
+        val uTx = TransactionViewTestHelper.unsafe(
           "txId",
           TxHash.fromStringUnsafe(
             "a8a935c6bc2bd8b3a7c20f107a9eb5f10a315ce27de9d72f3f4e27ac9ec1eb1f"
@@ -262,7 +263,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
 
         val utils = tr.testUtils
 
-        val uTx = TransactionView.unsafe(
+        val uTx = TransactionViewTestHelper.unsafe(
           "txId",
           TxHash.fromStringUnsafe(
             "a8a935c6bc2bd8b3a7c20f107a9eb5f10a315ce27de9d72f3f4e27ac9ec1eb1f"
@@ -277,7 +278,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
         )
         explorer.addToBC(uTx)
 
-        val tx = TransactionView.unsafe(
+        val tx = TransactionViewTestHelper.unsafe(
           "txId",
           TxHash.fromStringUnsafe(
             "a8a935c6bc2bd8b3a7c20f107a9eb5f10a315ce27de9d72f3f4e27ac9ec1eb1f"
@@ -318,7 +319,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
           "d0a75f8295419c72782aadb8de23b4d8ed095c9ec3c26a144b8e8f9ab0c11730"
         )
 
-        val uTx1 = TransactionView.unsafe(
+        val uTx1 = TransactionViewTestHelper.unsafe(
           "tx1",
           TxHash.fromStringUnsafe(
             "b23ed6a7362a45ed880d29aa601baed2ee718b440a562daf31473a65fc99d0c7"
@@ -463,7 +464,7 @@ class InterpreterIT extends AnyFlatSpec with ContainerSpec with Matchers {
 
         val uTx1 = AccountTxView(
           accountUid,
-          TransactionView.unsafe(
+          TransactionViewTestHelper.unsafe(
             "utx1",
             TxHash.fromStringUnsafe(
               "a99c7e333b287e7ecb017b33b7faf028a7eba69ae716114401e398f568f6ad9b"

--- a/src/it/scala/co/ledger/cria/domain/services/interpreter/OperationComputationServiceIT.scala
+++ b/src/it/scala/co/ledger/cria/domain/services/interpreter/OperationComputationServiceIT.scala
@@ -79,7 +79,7 @@ class OperationComputationServiceIT
   )
 
   val insertTx1: TransactionView =
-    TransactionView(
+    TransactionView.unsafe(
       "txId",
       TxHash.fromStringUnsafe("a8a935c6bc2bd8b3a7c20f107a9eb5f10a315ce27de9d72f3f4e27ac9ec1eb1f"),
       time,

--- a/src/it/scala/co/ledger/cria/domain/services/interpreter/OperationComputationServiceIT.scala
+++ b/src/it/scala/co/ledger/cria/domain/services/interpreter/OperationComputationServiceIT.scala
@@ -14,7 +14,8 @@ import co.ledger.cria.domain.models.interpreter.{
   Operation,
   OperationType,
   OutputView,
-  TransactionView
+  TransactionView,
+  TransactionViewTestHelper
 }
 import co.ledger.cria.domain.models.{Sort, TxHash, keychain}
 import co.ledger.cria.domain.models.keychain.{AccountAddress, ChangeType}
@@ -79,7 +80,7 @@ class OperationComputationServiceIT
   )
 
   val insertTx1: TransactionView =
-    TransactionView.unsafe(
+    TransactionViewTestHelper.unsafe(
       "txId",
       TxHash.fromStringUnsafe("a8a935c6bc2bd8b3a7c20f107a9eb5f10a315ce27de9d72f3f4e27ac9ec1eb1f"),
       time,

--- a/src/it/scala/co/ledger/cria/e2e/base/CriaE2ETest.scala
+++ b/src/it/scala/co/ledger/cria/e2e/base/CriaE2ETest.scala
@@ -59,8 +59,7 @@ class CriaE2ETest
   def readTestCases(): List[TestCase] =
     List(
       "test-accounts-btc.json",
-      // TODO Uncomment me when the explorers are stable (maybe ?)
-      //"test-accounts-btc_testnet.json",
+      "test-accounts-btc_testnet.json",
       "test-accounts-ltc.json"
     ).flatMap(TestCase.readJson)
 

--- a/src/it/scala/co/ledger/cria/itutils/LamaTestUtils.scala
+++ b/src/it/scala/co/ledger/cria/itutils/LamaTestUtils.scala
@@ -15,7 +15,7 @@ import co.ledger.cria.domain.models.interpreter.{
   BlockHeight,
   CurrentBalance,
   Operation,
-  TransactionView
+  TransactionViewTestHelper
 }
 import co.ledger.cria.domain.models.{Sort, TxHash}
 import co.ledger.cria.itutils.models._
@@ -148,7 +148,7 @@ final class LamaTestUtils private (conf: LamaDb, db: Transactor[IO]) extends Tes
       uid = emptyOperation.op.uid,
       accountId = emptyOperation.op.accountId,
       hash = emptyOperation.op.hash,
-      transaction = TransactionView.unsafe(
+      transaction = TransactionViewTestHelper.unsafe(
         id = emptyOperation.tx.id,
         hash = emptyOperation.tx.hash,
         receivedAt = emptyOperation.tx.receivedAt,

--- a/src/it/scala/co/ledger/cria/itutils/LamaTestUtils.scala
+++ b/src/it/scala/co/ledger/cria/itutils/LamaTestUtils.scala
@@ -148,7 +148,7 @@ final class LamaTestUtils private (conf: LamaDb, db: Transactor[IO]) extends Tes
       uid = emptyOperation.op.uid,
       accountId = emptyOperation.op.accountId,
       hash = emptyOperation.op.hash,
-      transaction = TransactionView(
+      transaction = TransactionView.unsafe(
         id = emptyOperation.tx.id,
         hash = emptyOperation.tx.hash,
         receivedAt = emptyOperation.tx.receivedAt,

--- a/src/it/scala/co/ledger/cria/itutils/queries/LamaOperationTestQueries.scala
+++ b/src/it/scala/co/ledger/cria/itutils/queries/LamaOperationTestQueries.scala
@@ -45,8 +45,8 @@ object LamaOperationTestQueries extends DoobieLogHandler {
         case ((txhash1, i), (txHash2, o)) if txhash1 == txHash2 =>
           OperationDetails(
             txhash1,
-            inputs = i.toList.flatten.sortBy(i => (i.outputHash, i.outputIndex)),
-            outputs = o.toList.flatten.sortBy(_.outputIndex)
+            inputs = i.toList.flatten.sortBy(i => i.inputIndex).distinct,
+            outputs = o.toList.flatten.sortBy(_.outputIndex).distinct
           )
       }
   }

--- a/src/main/scala/co/ledger/cria/domain/adapters/explorer/v2/TypeHelper.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/explorer/v2/TypeHelper.scala
@@ -67,15 +67,14 @@ object TypeHelper {
       for {
         inputs <- t.inputs.collect { case i: DefaultInput => i }.traverse(input.fromDefaultInput[F])
         block  <- t.block.traverse(block.fromExplorer[F])
-      } yield {
-        TransactionView(
-          t.hash,
-          txHash,
-          t.receivedAt,
-          t.lockTime,
-          t.fees,
-          inputs,
-          t.outputs.map { o =>
+        result <- TransactionView.asMonadError[F](
+          id = t.hash,
+          hash = txHash,
+          receivedAt = t.receivedAt,
+          lockTime = t.lockTime,
+          fees = t.fees,
+          inputs = inputs,
+          outputs = t.outputs.map { o =>
             OutputView(
               o.outputIndex,
               o.value,
@@ -85,10 +84,10 @@ object TypeHelper {
               None
             )
           },
-          block,
-          t.confirmations
+          block = block,
+          confirmations = t.confirmations
         )
-      }
+      } yield result
     }
   }
 

--- a/src/main/scala/co/ledger/cria/domain/adapters/explorer/v3/TypeHelper.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/explorer/v3/TypeHelper.scala
@@ -70,15 +70,14 @@ object TypeHelper {
     ): F[TransactionView] = {
       for {
         inputs <- t.inputs.collect { case i: DefaultInput => i }.traverse(input.fromDefaultInput[F])
-      } yield {
-        TransactionView(
-          t.id,
-          txHash,
-          t.receivedAt,
-          t.lockTime,
-          t.fees,
-          inputs,
-          t.outputs.map { o =>
+        result <- TransactionView.asMonadError[F](
+          id = t.hash,
+          hash = txHash,
+          receivedAt = t.receivedAt,
+          lockTime = t.lockTime,
+          fees = t.fees,
+          inputs = inputs,
+          outputs = t.outputs.map { o =>
             OutputView(
               o.outputIndex,
               o.value,
@@ -88,10 +87,10 @@ object TypeHelper {
               None
             )
           },
-          None,
-          t.confirmations
+          block = None,
+          confirmations = t.confirmations
         )
-      }
+      } yield result
     }
 
     private def confirmedTransaction[F[_]](t: explorer.ConfirmedTransaction, txHash: TxHash)(
@@ -100,15 +99,14 @@ object TypeHelper {
       for {
         blockView <- block.fromExplorer[F](t.block)
         inputs    <- t.inputs.collect { case i: DefaultInput => i }.traverse(input.fromDefaultInput[F])
-      } yield {
-        TransactionView(
-          t.id,
-          txHash,
-          t.receivedAt,
-          t.lockTime,
-          t.fees,
-          inputs,
-          t.outputs.map { o =>
+        result <- TransactionView.asMonadError[F](
+          id = t.hash,
+          hash = txHash,
+          receivedAt = t.receivedAt,
+          lockTime = t.lockTime,
+          fees = t.fees,
+          inputs = inputs,
+          outputs = t.outputs.map { o =>
             OutputView(
               o.outputIndex,
               o.value,
@@ -118,10 +116,10 @@ object TypeHelper {
               None
             )
           },
-          Some(blockView),
-          t.confirmations
+          block = Some(blockView),
+          confirmations = t.confirmations
         )
-      }
+      } yield result
     }
   }
 

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/lama/LamaOperationComputationService.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/lama/LamaOperationComputationService.scala
@@ -44,11 +44,11 @@ class LamaOperationComputationService(
           .fetchTransactionDetails(accountId, sort, NonEmptyList.one(row.hash))
           .map((row, _))
       )
-      .map { case (row, details) =>
+      .flatMap { case (row, details) =>
         val blockHeight = row.blockHeight
           .flatMap(h => BlockHeight.fromLong(h).toOption)
 
-        TransactionView(
+        TransactionView.asMonadError[fs2.Stream[ConnectionIO, *]](
           id = row.id,
           hash = row.hash,
           receivedAt = row.receivedAt,

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/models/WDTransactionRow.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/models/WDTransactionRow.scala
@@ -1,0 +1,63 @@
+package co.ledger.cria.domain.adapters.persistence.wd.models
+
+import co.ledger.cria.domain.models.TxHash
+import co.ledger.cria.domain.models.interpreter.{BlockHash, BlockHeight}
+import doobie.Read
+import doobie.postgres.implicits._
+import co.ledger.cria.domain.models.implicits._
+import co.ledger.cria.domain.adapters.persistence.wd.queries.WDQueryImplicits._
+
+import java.time.Instant
+
+case class WDTransactionRow(
+    id: String,
+    hash: TxHash,
+    blockHash: Option[BlockHash],
+    blockHeight: Option[BlockHeight],
+    blockTime: Option[Instant],
+    receivedAt: Instant,
+    lockTime: Long,
+    fees: BigInt,
+    confirmations: Int
+)
+
+object WDTransactionRow {
+  implicit lazy val readTransactionView: Read[WDTransactionRow] = {
+    Read[
+      (
+          String,
+          TxHash,
+          Option[BlockHash],
+          Option[BlockHeight],
+          Option[Instant],
+          Instant,
+          Long,
+          BigInt,
+          Int
+      )
+    ].map {
+      case (
+            id,
+            hash,
+            blockHashO,
+            blockHeightO,
+            blockTimeO,
+            receivedAt,
+            lockTime,
+            fees,
+            confirmations
+          ) =>
+        WDTransactionRow(
+          id = id,
+          hash = hash,
+          blockHash = blockHashO,
+          blockHeight = blockHeightO,
+          blockTime = blockTimeO,
+          receivedAt = receivedAt,
+          lockTime = lockTime,
+          fees = fees,
+          confirmations = confirmations
+        )
+    }
+  }
+}

--- a/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/queries/WDTransactionQueries.scala
+++ b/src/main/scala/co/ledger/cria/domain/adapters/persistence/wd/queries/WDTransactionQueries.scala
@@ -11,6 +11,7 @@ import doobie.implicits._
 import doobie.postgres.implicits._
 import fs2._
 import WDQueryImplicits._
+import co.ledger.cria.domain.adapters.persistence.wd.models.WDTransactionRow
 
 object WDTransactionQueries extends DoobieLogHandler {
 
@@ -128,7 +129,7 @@ object WDTransactionQueries extends DoobieLogHandler {
       accountId: AccountUid,
       sort: Sort,
       txHashes: NonEmptyList[TxHash]
-  ): Stream[doobie.ConnectionIO, TransactionView] = {
+  ): Stream[doobie.ConnectionIO, WDTransactionRow] = {
     log.logger.debug(
       s"Fetching transactions for accountId $accountId and hashes in $txHashes"
     )
@@ -150,7 +151,7 @@ object WDTransactionQueries extends DoobieLogHandler {
          WHERE t.account_uid = $accountId
            AND $belongsToTxs
        """ ++ transactionOrder(sort))
-      .query[TransactionView]
+      .query[WDTransactionRow]
       .stream
   }
 

--- a/src/main/scala/co/ledger/cria/domain/models/implicits.scala
+++ b/src/main/scala/co/ledger/cria/domain/models/implicits.scala
@@ -1,16 +1,11 @@
 package co.ledger.cria.domain.models
 
-import java.time.Instant
 import cats.data.NonEmptyList
 import co.ledger.cria.domain.models.account.{AccountUid, WalletUid}
-import co.ledger.cria.domain.models.interpreter.{OperationType, TransactionView}
-import co.ledger.cria.domain.models.interpreter._
+import co.ledger.cria.domain.models.interpreter.OperationType
 import co.ledger.cria.domain.models.keychain.ChangeType
 import doobie._
 import doobie.postgres.implicits._
-import doobie.refined.implicits.refinedMeta
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.NonNegative
 
 import scala.math.BigDecimal.javaBigDecimal2bigDecimal
 
@@ -36,48 +31,4 @@ object implicits {
 
   implicit val doobieMetaWalletUid: Meta[WalletUid] =
     Meta[String].timap[WalletUid](WalletUid)(_.value)
-
-  implicit lazy val readTransactionView: Read[TransactionView] = {
-    implicit val metaBlockHeight: Meta[BlockHeight] =
-      refinedMeta[Long, NonNegative, Refined].timap[BlockHeight](BlockHeight(_))(_.height)
-    val _ = metaBlockHeight
-
-    Read[
-      (
-          String,
-          TxHash,
-          Option[BlockHash],
-          Option[BlockHeight],
-          Option[Instant],
-          Instant,
-          Long,
-          BigInt,
-          Int
-      )
-    ].map {
-      case (
-            id,
-            hash,
-            blockHashO,
-            blockHeightO,
-            blockTimeO,
-            receivedAt,
-            lockTime,
-            fees,
-            confirmations
-          ) =>
-        TransactionView(
-          id = id,
-          hash = hash,
-          receivedAt = receivedAt,
-          lockTime = lockTime,
-          fees = fees,
-          inputs = Seq(),
-          outputs = Seq(),
-          block =
-            blockHashO.map(blockHash => BlockView(blockHash, blockHeightO.get, blockTimeO.get)),
-          confirmations = confirmations
-        )
-    }
-  }
 }

--- a/src/main/scala/co/ledger/cria/domain/models/interpreter/TransactionView.scala
+++ b/src/main/scala/co/ledger/cria/domain/models/interpreter/TransactionView.scala
@@ -1,9 +1,13 @@
 package co.ledger.cria.domain.models.interpreter
 
+import cats.MonadError
+import cats.data.{Validated, ValidatedNel}
 import co.ledger.cria.domain.models.TxHash
+import cats.implicits._
 
 import java.time.Instant
-case class TransactionView(
+
+final case class TransactionView private (
     id: String,
     hash: TxHash,
     receivedAt: Instant,
@@ -14,3 +18,105 @@ case class TransactionView(
     block: Option[BlockView],
     confirmations: Int
 )
+
+object TransactionView {
+
+  def apply(
+      id: String,
+      hash: TxHash,
+      receivedAt: Instant,
+      lockTime: Long,
+      fees: BigInt,
+      inputs: Seq[InputView],
+      outputs: Seq[OutputView],
+      block: Option[BlockView],
+      confirmations: Int
+  ): ValidatedNel[String, TransactionView] = {
+    val sortedInputs  = inputs.sortBy(_.inputIndex)
+    val sortedOutputs = outputs.sortBy(_.outputIndex)
+
+    val checkInputs: ValidatedNel[String, Unit] =
+      sortedInputs.zipWithIndex.traverse { case (input, idx) =>
+        Validated.condNel(
+          input.inputIndex == idx,
+          (),
+          s"input at index $idx has input index ${input.inputIndex}"
+        )
+      }.void
+
+    val checkOutputs: ValidatedNel[String, Unit] =
+      sortedOutputs.zipWithIndex.traverse { case (output, idx) =>
+        Validated.condNel(
+          output.outputIndex == idx,
+          (),
+          s"output at index $idx has output index ${output.outputIndex}"
+        )
+      }.void
+
+    val checkFees: ValidatedNel[String, BigInt] = {
+      val computedFees = inputs.foldMap(_.value) - outputs.foldMap(_.value)
+      Validated.condNel(fees >= 0, (), s"Fees should be non negative. Got $fees") *>
+        Validated.condNel(fees == computedFees, fees, s"Fees does not match inputs/outputs")
+    }
+
+    def mkTxView(fees: BigInt): TransactionView =
+      new TransactionView(
+        id = id,
+        hash = hash,
+        receivedAt = receivedAt,
+        lockTime = lockTime,
+        fees = fees,
+        inputs = sortedInputs,
+        outputs = sortedOutputs,
+        block = block,
+        confirmations = confirmations
+      )
+
+    (checkInputs *> checkOutputs *> checkFees).map(mkTxView)
+  }
+
+  def asMonadError[F[_]](
+      id: String,
+      hash: TxHash,
+      receivedAt: Instant,
+      lockTime: Long,
+      fees: BigInt,
+      inputs: Seq[InputView],
+      outputs: Seq[OutputView],
+      block: Option[BlockView],
+      confirmations: Int
+  )(implicit F: MonadError[F, Throwable]): F[TransactionView] = {
+    val asValidatedNel: ValidatedNel[String, TransactionView] =
+      TransactionView(id, hash, receivedAt, lockTime, fees, inputs, outputs, block, confirmations)
+    F.fromValidated(
+      asValidatedNel.leftMap(errors =>
+        new IllegalArgumentException(
+          s"Can not instantiate a transaction with hash ${hash.asString}:\n${errors.toList.map("- " + _).mkString("\n")}"
+        )
+      )
+    )
+  }
+
+  def unsafe(
+      id: String,
+      hash: TxHash,
+      receivedAt: Instant,
+      lockTime: Long,
+      fees: BigInt,
+      inputs: Seq[InputView],
+      outputs: Seq[OutputView],
+      block: Option[BlockView],
+      confirmations: Int
+  ): TransactionView =
+    asMonadError[Either[Throwable, *]](
+      id,
+      hash,
+      receivedAt,
+      lockTime,
+      fees,
+      inputs,
+      outputs,
+      block,
+      confirmations
+    ).fold[TransactionView](throw _, identity)
+}

--- a/src/main/scala/co/ledger/cria/domain/models/interpreter/TransactionView.scala
+++ b/src/main/scala/co/ledger/cria/domain/models/interpreter/TransactionView.scala
@@ -96,27 +96,4 @@ object TransactionView {
       )
     )
   }
-
-  def unsafe(
-      id: String,
-      hash: TxHash,
-      receivedAt: Instant,
-      lockTime: Long,
-      fees: BigInt,
-      inputs: Seq[InputView],
-      outputs: Seq[OutputView],
-      block: Option[BlockView],
-      confirmations: Int
-  ): TransactionView =
-    asMonadError[Either[Throwable, *]](
-      id,
-      hash,
-      receivedAt,
-      lockTime,
-      fees,
-      inputs,
-      outputs,
-      block,
-      confirmations
-    ).fold[TransactionView](throw _, identity)
 }

--- a/src/test/scala/co/ledger/cria/TransactionFixture.scala
+++ b/src/test/scala/co/ledger/cria/TransactionFixture.scala
@@ -1,6 +1,7 @@
 package co.ledger.cria
 
 import cats.data.NonEmptyList
+import cats.implicits.toFoldableOps
 import co.ledger.cria.clients.explorer.v3.ExplorerClient.Address
 import co.ledger.cria.domain.models.TxHash
 import co.ledger.cria.domain.models.interpreter.{
@@ -78,12 +79,12 @@ object TransactionFixture {
       inputs: NonEmptyList[InputView],
       outputs: NonEmptyList[OutputView]
   ): TransactionView @@ Confirmation.Unconfirmed = tag[Confirmation.Unconfirmed](
-    TransactionView(
+    TransactionView.unsafe(
       id = s"id-${Random.nextInt(100)}",
       hash = randomTxHash(),
       receivedAt = Instant.now(),
       lockTime = 0L,
-      fees = 1,
+      fees = inputs.foldMap(_.value) - outputs.foldMap(_.value),
       inputs = inputs.toList,
       outputs = outputs.toList,
       None,
@@ -96,12 +97,12 @@ object TransactionFixture {
       outputs: NonEmptyList[OutputView],
       block: BlockView
   ): TransactionView @@ Confirmation.Confirmed = tag[Confirmation.Confirmed](
-    TransactionView(
+    TransactionView.unsafe(
       id = s"id-${Random.nextInt(100) + 100}",
       hash = randomTxHash(),
       receivedAt = Instant.now(),
       lockTime = 0L,
-      fees = 1,
+      fees = inputs.foldMap(_.value) - outputs.foldMap(_.value),
       inputs = inputs.toList,
       outputs = outputs.toList,
       confirmations = 1,

--- a/src/test/scala/co/ledger/cria/TransactionFixture.scala
+++ b/src/test/scala/co/ledger/cria/TransactionFixture.scala
@@ -9,7 +9,8 @@ import co.ledger.cria.domain.models.interpreter.{
   Confirmation,
   InputView,
   OutputView,
-  TransactionView
+  TransactionView,
+  TransactionViewTestHelper
 }
 import co.ledger.cria.utils.HexUtils
 import shapeless.tag
@@ -79,7 +80,7 @@ object TransactionFixture {
       inputs: NonEmptyList[InputView],
       outputs: NonEmptyList[OutputView]
   ): TransactionView @@ Confirmation.Unconfirmed = tag[Confirmation.Unconfirmed](
-    TransactionView.unsafe(
+    TransactionViewTestHelper.unsafe(
       id = s"id-${Random.nextInt(100)}",
       hash = randomTxHash(),
       receivedAt = Instant.now(),
@@ -97,7 +98,7 @@ object TransactionFixture {
       outputs: NonEmptyList[OutputView],
       block: BlockView
   ): TransactionView @@ Confirmation.Confirmed = tag[Confirmation.Confirmed](
-    TransactionView.unsafe(
+    TransactionViewTestHelper.unsafe(
       id = s"id-${Random.nextInt(100) + 100}",
       hash = randomTxHash(),
       receivedAt = Instant.now(),

--- a/src/test/scala/co/ledger/cria/domain/models/interpreter/TransactionViewTest.scala
+++ b/src/test/scala/co/ledger/cria/domain/models/interpreter/TransactionViewTest.scala
@@ -1,0 +1,147 @@
+package co.ledger.cria.domain.models.interpreter
+
+import co.ledger.cria.domain.models.TxHash
+import org.scalatest.funsuite.AnyFunSuite
+import cats.implicits._
+import java.time.Instant
+
+class TransactionViewTest extends AnyFunSuite {
+
+  test("Can make a valid transaction") {
+    val tx = makeTx(
+      fees = 300,
+      List(input0, input1),
+      List(output0, output1)
+    )
+
+    assert(tx.isRight)
+  }
+
+  test("Can't have non-matching fees in transaction") {
+
+    val tx = makeTx(
+      fees = 500, // Should be 300
+      List(input0, input1),
+      List(output0, output1)
+    )
+
+    assert(tx.isLeft)
+  }
+
+  test("Can't have negative fees in transaction") {
+
+    val tx = makeTx(
+      fees = -1700, // Should not be negative
+      List(input0),
+      List(output0, output1)
+    )
+
+    assert(tx.isLeft)
+  }
+
+  test("Can't have input in double") {
+
+    val tx = makeTx(
+      fees = 1100,
+      List(input0, input0), // Can't have input with index 0 twice
+      List(output0)
+    )
+
+    assert(tx.isLeft)
+  }
+
+  test("Can't have output in double") {
+
+    val tx = makeTx(
+      fees = 1200,
+      List(input0, input1),
+      List(output0, output0) // Output at index 0 is there twice
+    )
+
+    assert(tx.isLeft)
+  }
+
+  test("Can't have hole in inputs") {
+    val input2 = input1.copy(inputIndex = 2)
+
+    val tx = makeTx(
+      fees = 300,
+      List(input0, input2), // No input at index 1
+      List(output0, output1)
+    )
+
+    assert(tx.isLeft)
+  }
+
+  test("Can't have hole in outputs") {
+    val output2 = output1.copy(outputIndex = 2)
+
+    val tx = makeTx(
+      fees = 300,
+      List(input0, input1),
+      List(output0, output2) // No output at index 2
+    )
+
+    assert(tx.isLeft)
+  }
+
+  private def makeTx(
+      fees: BigInt,
+      inputs: List[InputView],
+      outputs: List[OutputView]
+  ): Either[Throwable, TransactionView] =
+    TransactionView.asMonadError[Either[Throwable, *]](
+      id = "tx",
+      hash =
+        TxHash.fromStringUnsafe("edc8e160364384332a2c95dd17d0d66612d53a8711739416d6372e75474d40ab"),
+      receivedAt = Instant.now(),
+      lockTime = 0,
+      fees = fees,
+      inputs = inputs,
+      outputs = outputs, // No output at index 2
+      None,
+      0
+    )
+
+  private lazy val input0 = InputView(
+    TxHash.fromStringUnsafe("c569d424111eaa8d66c7a1124c203c65649197b9855e54563dfc2799da928c1c"),
+    0,
+    0,
+    1000,
+    "address0",
+    "SIG",
+    Nil,
+    0,
+    None
+  )
+
+  private lazy val input1 = InputView(
+    TxHash.fromStringUnsafe("c849117bf6203c900e649f46bb35f5e8b939c5cc89cc39086c7c09ff202acda3"),
+    0,
+    1,
+    2000,
+    "address1",
+    "SIG",
+    Nil,
+    0,
+    None
+  )
+
+  private lazy val output0 = OutputView(
+    0,
+    900,
+    "out_address_0",
+    "script0",
+    None,
+    None
+  )
+
+  private lazy val output1 = OutputView(
+    1,
+    1800,
+    "out_address_1",
+    "script0",
+    None,
+    None
+  )
+}

--- a/src/test/scala/co/ledger/cria/domain/models/interpreter/TransactionViewTest.scala
+++ b/src/test/scala/co/ledger/cria/domain/models/interpreter/TransactionViewTest.scala
@@ -79,7 +79,7 @@ class TransactionViewTest extends AnyFunSuite {
     val tx = makeTx(
       fees = 300,
       List(input0, input1),
-      List(output0, output2) // No output at index 2
+      List(output0, output2) // No output at index 1
     )
 
     assert(tx.isLeft)
@@ -98,7 +98,7 @@ class TransactionViewTest extends AnyFunSuite {
       lockTime = 0,
       fees = fees,
       inputs = inputs,
-      outputs = outputs, // No output at index 2
+      outputs = outputs,
       None,
       0
     )

--- a/src/test/scala/co/ledger/cria/domain/models/interpreter/TransactionViewTestHelper.scala
+++ b/src/test/scala/co/ledger/cria/domain/models/interpreter/TransactionViewTestHelper.scala
@@ -1,0 +1,31 @@
+package co.ledger.cria.domain.models.interpreter
+
+import co.ledger.cria.domain.models.TxHash
+import co.ledger.cria.domain.models.interpreter.TransactionView.asMonadError
+
+import java.time.Instant
+
+object TransactionViewTestHelper {
+  def unsafe(
+      id: String,
+      hash: TxHash,
+      receivedAt: Instant,
+      lockTime: Long,
+      fees: BigInt,
+      inputs: Seq[InputView],
+      outputs: Seq[OutputView],
+      block: Option[BlockView],
+      confirmations: Int
+  ): TransactionView =
+    asMonadError[Either[Throwable, *]](
+      id,
+      hash,
+      receivedAt,
+      lockTime,
+      fees,
+      inputs,
+      outputs,
+      block,
+      confirmations
+    ).fold[TransactionView](throw _, identity)
+}


### PR DESCRIPTION
This commit improve the checks on transaction so the program can't
instantiate transactions which are obviously wrong, whether they come
from the explorers or the DB.

This is done in the hope to catch invalid transaction early and fail the
synchronization instead of succeeding the transaction with erroneous
data.

Currenty checked:
- Fees can't be negative
- Fees must match `inputs - outputs`
- Can't have two inputs with same index
- Can't have two outputs with same index
- Can't have holes in inputs (e.g an input with idx 0, another with idx
  2 but no input with idx 1)
- Can't have holes in outputs

![lama](https://opensanctuary.org/wp-content/uploads/2018/06/The-Open-Sanctuary-Project-Llama-Health-Exam.jpg)
