### PR TITLE
Fix test data for ltc

### DIFF
--- a/src/it/e2e-resources/test-accounts-ltc.json
+++ b/src/it/e2e-resources/test-accounts-ltc.json
@@ -14,11 +14,11 @@
       "metadata": "nolibcore:testworkspace"
     },
     "expected": {
-      "ops_size": 19,
-      "utxos_size": 4,
-      "balance": 74467599,
+      "ops_size": 21,
+      "utxos_size": 3,
+      "balance": 71466999,
       "amount_received": 96422825,
-      "amount_sent": 21955226
+      "amount_sent": 24955826
     }
   }
 ]


### PR DESCRIPTION
Someone made new operations on our ltc test key. This commit updates the
expected synchronization results.

![lama](https://static.displate.com/857x1200/displate/2018-12-10/71cc55cbd3520b3a934cc261a9dbee5b_fd3efe114c3746ae28a5cbc89a508a4d.jpg)
